### PR TITLE
Fix links to Haskell implementation of Day.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # purescript-day
 
 Day Convolution of contravariant functors, based on 
-<https://hackage.haskell.org/package/contravariant/docs/Data-Functor-Day.html>.
+<https://hackage.haskell.org/package/kan-extensions/docs/Data-Functor-Day.html>.
 
 Documentation is available on [Pursuit](https://pursuit.purescript.org/packages/purescript-day).

--- a/src/Data/Functor/Day.purs
+++ b/src/Data/Functor/Day.purs
@@ -1,6 +1,6 @@
 -- | The Day convolution of covariant functors.
 -- |
--- | Based on <https://hackage.haskell.org/package/contravariant/docs/Data-Functor-Day.html>
+-- | Based on <https://hackage.haskell.org/package/kan-extensions/docs/Data-Functor-Day.html>
 
 module Data.Functor.Day
   ( Day


### PR DESCRIPTION
The existing link https://hackage.haskell.org/package/contravariant/docs/Data-Functor-Day.html goes to a page displaying:

```
Page not found

Sorry, it's just not here.
```

New link: https://hackage.haskell.org/package/kan-extensions/docs/Data-Functor-Day.html
